### PR TITLE
Fix : Image overflow and fixed image cropping on small devices

### DIFF
--- a/client/src/CSS/Image.css
+++ b/client/src/CSS/Image.css
@@ -8,6 +8,7 @@
     @media (max-width:710px)
     {
         height:24vh;
+        padding-bottom: 1rem;
     }
 }
 
@@ -17,6 +18,7 @@
     overflow-x: auto;
     scrollbar-width: none;
     -ms-overflow-style: none;
+    overflow-y: hidden;
 }
 
 .image-con::-webkit-scrollbar{


### PR DESCRIPTION
### Closes : #192 

#### 1. This section of scrollable images was overflowing in y-direction i.e making the image scroll vertically so fixed it.
#### 2. Another thing i fixed is after fixing the overflow image container was getting `cropped` on small screens so in order to have `equal white space` around images added `bottom-padding`.

 - This card section has improved for small screens !

![image](https://github.com/DevFeed404/DevFeed-1.0/assets/115401171/01607cca-1dfe-4326-8db8-4ed0a96fc86c)


#### Note : I'm a gssoc contributor so please add required labels*